### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+libagentcore.so
+plugins/


### PR DESCRIPTION
I suspect the absence of this may be why after an `npm install` in appmetrics, the omr-agentcore module is always described as "dirty", and the git status shows up as modified, even though no changes have been made other than build side-effects.

```
sn/appmetrics (master *% u=) % git s
 M omr-agentcore
?? plugins/
sn/appmetrics (master *% u=) % git diff
diff --git a/omr-agentcore b/omr-agentcore
--- a/omr-agentcore
+++ b/omr-agentcore
@@ -1 +1 @@
-Subproject commit caf73931204bba16a0383768a50d4573f2fa99a9
+Subproject commit caf73931204bba16a0383768a50d4573f2fa99a9-dirty

```
