### PR TITLE
Remove extraneous debug from Package.swift + fix Memory Leak

### DIFF
--- a/src/ibmras/monitoring/connector/api/APIConnector.cpp
+++ b/src/ibmras/monitoring/connector/api/APIConnector.cpp
@@ -38,7 +38,7 @@ void (*listener)(const char*, unsigned int, void*);
 int APIConnector::sendMessage(const std::string &sourceId, uint32 size, void *data) {
 	if (listener != NULL) {
 		char* asciiString = ibmras::common::util::createAsciiString(sourceId.c_str());
-		listener(ibmras::common::util::createAsciiString(sourceId.c_str()), size, data);
+		listener(asciiString, size, data);
 		ibmras::common::memory::deallocate((unsigned char**)&asciiString);
 	}
 	return size;


### PR DESCRIPTION
As well as removing debugging code from Package.swift, this pull requests also contains a fix for a memory leak - the calls to createAsciiString() and createNativeString() in APIConnector caused memory to be allocated that was not deallocated. Deallocation of memory now explicitly happens in APIConnector.
