### PR TITLE
Remove 32-bit Travis build configs for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ language: cpp
 matrix:
     include:
         - os: linux
-          env: BUILD=xi32
-        - os: linux
           env: BUILD=xa64
-        - os: osx
-          env: BUILD=darwin
         - os: osx
           env: BUILD=darwin64
 


### PR DESCRIPTION
Baseline should be green, so let's remove the 32-bit Travis build configs for now so that master is building green.
