### PR TITLE
env plugin: Correct name for Windows Server 2012

### DIFF
--- a/src/ibmras/monitoring/plugins/common/environment/envplugin.cpp
+++ b/src/ibmras/monitoring/plugins/common/environment/envplugin.cpp
@@ -520,7 +520,7 @@ const std::string EnvPlugin::GetWindowsMajorVersion() {
 				switch (versionInfo.dwMinorVersion) {
 				case 0: return "Windows Server 2008";
 				case 1: return "Windows Server 2008 R2";
-				case 2: return "Windows Server 8";
+				case 2: return "Windows Server 2012";
 				default: return defaultVersion;
 				}
 			}


### PR DESCRIPTION
The server version of Windows 6.2 is called `Windows 2012` according to the table on https://msdn.microsoft.com/en-gb/library/windows/desktop/ms724832%28v=vs.85%29.aspx