### PR TITLE
Allow loading from AIX .a shared libraries

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -49,7 +49,7 @@
     "conditions": [
       ['OS=="aix"', {
         "defines": [ "_AIX", "AIX" ],
-        "libraries": [ "-Wl,-bexpall,-brtllib,-G,-bernotok,-brtl" ],
+        "libraries": [ "-Wl,-bexpall,-brtllib,-G,-bernotok,-brtl,-L.,-bnoipath" ],
       }],
       ['OS=="mac"', {
         "defines": [ "__MACH__", "__APPLE__",  ],

--- a/src/ibmras/monitoring/agent/Agent.cpp
+++ b/src/ibmras/monitoring/agent/Agent.cpp
@@ -43,7 +43,11 @@ const char* LIBSUFFIX = ".dll";
 #define AGENT_DECL
 const char PATHSEPARATOR = '/';
 const char* LIBPREFIX = "lib";
+#if defined(AIX)
+const char* LIBSUFFIX = ".a";
+#else
 const char* LIBSUFFIX = ".so";
+#endif
 #endif
 
 


### PR DESCRIPTION
This uses bnoipath to strip the path from the libagentcore.a required library, allowing us to substitute the path . so that it can find it in the right place. Also allows Agent to recognise .a files as being valid library files.