### PR TITLE
Expose addPlugin through loaderCoreFunctions

### DIFF
--- a/src/ibmras/monitoring/AgentExtensions.h
+++ b/src/ibmras/monitoring/AgentExtensions.h
@@ -125,6 +125,7 @@ typedef int (*loadPropFunc)(const char* filename);
 typedef const char* (*getVer)();
 typedef void (*setLogLvls)();
 typedef void (*registerZipFn)(void(*)(const char*));
+typedef void (*addPlgn)(const char*);
 
 typedef struct agentCoreFunctions {
 	pushData agentPushData;
@@ -146,6 +147,7 @@ typedef struct loaderCoreFunctions {
 	getVer getAgentVersion;
 	setLogLvls setLogLevels;
 	registerZipFn registerZipFunction;
+    addPlgn addPlugin;
 
 } loaderCoreFunctions;
 

--- a/src/ibmras/monitoring/agent/Agent.cpp
+++ b/src/ibmras/monitoring/agent/Agent.cpp
@@ -79,6 +79,7 @@ AGENT_DECL loaderCoreFunctions* loader_entrypoint() {
 	lCF->getAgentVersion = getVersionWrapper;
 	lCF->setLogLevels = setLogLevelsWrapper;
 	lCF->registerZipFunction = registerZipFunctionWrapper;
+    lCF->addPlugin = addPluginWrapper;
 
 	return lCF;
 }
@@ -150,6 +151,10 @@ bool loadPropertiesFileWrapper(const char* fileName) {
 
 void registerZipFunctionWrapper(void(*zipFunc)(const char*)) {
 	return ibmras::monitoring::agent::Agent::getInstance()->registerZipFunction(zipFunc);
+}
+
+void addPluginWrapper(const char* completeLibraryPath) {
+	return ibmras::monitoring::agent::Agent::getInstance()->addPlugin(completeLibraryPath);
 }
 
 } // extern "C"
@@ -435,6 +440,14 @@ void Agent::addPlugin(ibmras::monitoring::Plugin* plugin) {
 
 void Agent::addPlugin(const std::string &dir, const std::string library) {
 	ibmras::monitoring::Plugin *plugin = ibmras::monitoring::Plugin::processLibrary(dir + PATHSEPARATOR + LIBPREFIX + library + LIBSUFFIX);
+	if (plugin) {
+		IBMRAS_LOG_2(fine, "%s, version %s", (plugin->name).c_str(), (plugin->getVersion()));
+		plugins.push_back(plugin);
+	}
+}
+
+void Agent::addPlugin(const char* completeLibraryPath) {
+	ibmras::monitoring::Plugin *plugin = ibmras::monitoring::Plugin::processLibrary(std::string(completeLibraryPath));
 	if (plugin) {
 		IBMRAS_LOG_2(fine, "%s, version %s", (plugin->name).c_str(), (plugin->getVersion()));
 		plugins.push_back(plugin);

--- a/src/ibmras/monitoring/agent/Agent.h
+++ b/src/ibmras/monitoring/agent/Agent.h
@@ -50,6 +50,7 @@ void setPropertyWrapper(const char* key, const char* value);
 const char* getPropertyWrapper(const char* key);
 bool loadPropertiesFileWrapper(const char* fileName);
 void registerZipFunctionWrapper(void(*zF)(const char*));
+void addPluginWrapper(const char*);
 
 }
 
@@ -95,6 +96,7 @@ public:
 	void setLocalLog(bool local);
 	void addPlugin(ibmras::monitoring::Plugin* plugin);	/* manually add a plugin to the agent */
 	void addPlugin(const std::string &dir, const std::string library);	/* manually add a plugin to the agent */
+    void addPlugin(const char* completeLibraryPath);	/* manually add a plugin to the agent */
 
 	ibmras::common::Properties getProperties();
 	void setProperties(const ibmras::common::Properties &props);


### PR DESCRIPTION
This update allows the end user to use lCF->addPlugin(const char* completeLibraryPath) to add their individual plugin libraries to agentcore, rather than having them all be in one directory to be scanned. Crucially for Node, the suffix is not set so it is now possible to load Node Addons as plugins (they have a .node suffix).