### PR TITLE
Workaround stringstream << Int crash

### DIFF
--- a/src/ibmras/common/common.h
+++ b/src/ibmras/common/common.h
@@ -24,9 +24,13 @@ namespace common {
 
 template <class T>
 std::string itoa(T t) {
+#ifdef _WINDOWS
+    return std::to_string(t);
+#else
 	std::stringstream s;
 	s << t;
 	return s.str();
+#endif
 }
 
 }


### PR DESCRIPTION
Node 7.7.4 is crashing out whenever we do std::stringstream << Int on Windows.
This works around the problem by using std::to_string() on Windows instread.