### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/org.eclipse.paho.mqtt.c/src/MQTTAsync.c
+++ b/org.eclipse.paho.mqtt.c/src/MQTTAsync.c
@@ -1509,7 +1509,7 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 				qEntry* qe = (qEntry*)(m->c->messageQueue->first->content);
 				int topicLen = qe->topicLen;
 
-				if (strlen(qe->topicName) == topicLen)
+				if (topicLen >= 0 && strlen(qe->topicName) == (size_t)topicLen)
 					topicLen = 0;
 
 				if (m->ma)

--- a/org.eclipse.paho.mqtt.c/src/MQTTPersistence.c
+++ b/org.eclipse.paho.mqtt.c/src/MQTTPersistence.c
@@ -284,7 +284,8 @@ void* MQTTPersistence_restorePacket(char* buffer, size_t buflen)
 		fixed_header_length++;
 	} while ((c & 128) != 0);
 
-	if ( (fixed_header_length + remaining_length) == buflen )
+	int total_length = fixed_header_length = remaining_length;
+	if ( total_length >= 0 && (size_t)total_length == buflen )
 	{
 		ptype = header.bits.type;
 		if (ptype >= CONNECT && ptype <= DISCONNECT && new_packets[ptype] != NULL)

--- a/org.eclipse.paho.mqtt.c/src/Messages.c
+++ b/org.eclipse.paho.mqtt.c/src/Messages.c
@@ -97,9 +97,9 @@ char* Messages_get(int index, int log_level)
 	char* msg = NULL;
 
 	if (log_level == TRACE_PROTOCOL)
-		msg = (index >= 0 && index < ARRAY_SIZE(protocol_message_list)) ? protocol_message_list[index] : NULL;
+		msg = (index >= 0 && (size_t)index < ARRAY_SIZE(protocol_message_list)) ? protocol_message_list[index] : NULL;
 	else
-		msg = (index >= 0 && index < ARRAY_SIZE(trace_message_list)) ? trace_message_list[index] : NULL;
+		msg = (index >= 0 && (size_t)index < ARRAY_SIZE(trace_message_list)) ? trace_message_list[index] : NULL;
 	return msg;
 }
 

--- a/org.eclipse.paho.mqtt.c/src/Socket.c
+++ b/org.eclipse.paho.mqtt.c/src/Socket.c
@@ -463,7 +463,7 @@ int Socket_putdatas(int socket, char* buf0, size_t buf0len, int count, char** bu
 
 	if ((rc = Socket_writev(socket, iovecs, count+1, &bytes)) != SOCKET_ERROR)
 	{
-		if (bytes == total)
+		if (total >= 0 && bytes == (size_t)total)
 			rc = TCPSOCKET_COMPLETE;
 		else
 		{
@@ -744,7 +744,7 @@ int Socket_continueWrite(int socket)
 	if ((rc = Socket_writev(socket, iovecs1, curbuf+1, &bytes)) != SOCKET_ERROR)
 	{
 		pw->bytes += bytes;
-		if ((rc = (pw->bytes == pw->total)))
+		if ((rc = (pw->total >= 0 && pw->bytes == (size_t)pw->total)))
 		{  /* topic and payload buffers are freed elsewhere, when all references to them have been removed */
 			for (i = 0; i < pw->count; i++)
 			{

--- a/org.eclipse.paho.mqtt.c/src/utf-8.c
+++ b/org.eclipse.paho.mqtt.c/src/utf-8.c
@@ -73,7 +73,8 @@ const char* UTF8_char_validate(int len, const char* data)
 {
 	int good = 0;
 	int charlen = 2;
-	int i, j;
+	size_t i;
+	int j;
 	const char *rc = NULL;
 
 	FUNC_ENTRY;

--- a/src/ibmras/monitoring/Plugin.cpp
+++ b/src/ibmras/monitoring/Plugin.cpp
@@ -52,9 +52,9 @@ const char* SYM_RECEIVE_MESSAGE = "ibmras_monitoring_receiveMessage";
 const char* SYM_VERSION = "ibmras_monitoring_getVersion";
 
 Plugin::Plugin() :
-		name(""), init(NULL), push(NULL), pull(NULL), start(NULL), stop(NULL), confactory(
-				NULL), recvfactory(NULL), receiveMessage(NULL), type(0), version(0), getVersion(NULL) {
-}
+		name(""), version(0), init(NULL), push(NULL), pull(NULL), start(NULL),
+		stop(NULL), getVersion(NULL), confactory(NULL), recvfactory(NULL),
+		receiveMessage(NULL), type(0) { }
 
 std::vector<Plugin*> Plugin::scan(const std::string& dir) {
 

--- a/src/ibmras/monitoring/connector/headless/HLConnector.cpp
+++ b/src/ibmras/monitoring/connector/headless/HLConnector.cpp
@@ -75,8 +75,8 @@ HLConnector* HLConnector::getInstance() {
 }
 
 HLConnector::HLConnector() :
-		enabled(false), running(false), filesInitialized(false), seqNumber(
-				1), lastPacked(0), times_run(0), startDelay(0) {
+		enabled(false), running(false), filesInitialized(false),
+				lastPacked(0), times_run(0), startDelay(0) {
 
 	number_runs = 0;
 	run_duration = 0;
@@ -370,9 +370,6 @@ int HLConnector::stop() {
 	if (enabled == false) {
 		return 0;
 	}
-
-	ibmras::monitoring::agent::Agent* agent =
-				ibmras::monitoring::agent::Agent::getInstance();
 
 	// Take lock before packing then clearing the files
 	if (!lock->acquire()) {

--- a/src/ibmras/monitoring/connector/headless/HLConnector.h
+++ b/src/ibmras/monitoring/connector/headless/HLConnector.h
@@ -57,7 +57,6 @@ private:
 	bool running;
 	bool filesInitialized;
 
-	int32 seqNumber;
 	time_t lastPacked;
 	uint32 upper_limit;
 	int32 files_to_keep;

--- a/src/ibmras/monitoring/plugins/common/cpu/cpuplugin.cpp
+++ b/src/ibmras/monitoring/plugins/common/cpu/cpuplugin.cpp
@@ -65,7 +65,7 @@ CpuPlugin* CpuPlugin::instance = 0;
 agentCoreFunctions CpuPlugin::aCF;
 
 	CpuPlugin::CpuPlugin(uint32 provID):
-			provID(provID), noFailures(false), current(NULL), last(NULL){
+			provID(provID), noFailures(false), last(NULL), current(NULL) {
 	}
 
 	CpuPlugin::~CpuPlugin(){}

--- a/src/ibmras/monitoring/plugins/common/environment/envplugin.cpp
+++ b/src/ibmras/monitoring/plugins/common/environment/envplugin.cpp
@@ -383,7 +383,7 @@ std::string EnvPlugin::GetCommandLine() {
 	int argsPos = commandOutput.find(app);
 	std::string argv;
 
-	if(argsPos != std::string::npos) {
+	if(argsPos >= 0 && (size_t)argsPos != std::string::npos) {
 		argv = commandOutput.substr(argsPos);
 	} else {
 


### PR DESCRIPTION
Companion to https://github.com/RuntimeTools/appmetrics/pull/449. Fixes compiler warnings when building appmetrics on macOS Sierra.

Caveat emptor