### PR TITLE
Size of data should include null terminator

### DIFF
--- a/src/cpuplugin/cpuplugin.cpp
+++ b/src/cpuplugin/cpuplugin.cpp
@@ -172,7 +172,8 @@ agentCoreFunctions CpuPlugin::aCF;
 			AppendCPUTime(contentss);
 
 			std::string content = contentss.str();
-			data->size = static_cast<uint32>(content.length()); // should data->size be a size_t?
+			uint32 cSize = static_cast<uint32>(content.length() + 1);  // +1 to include null terminator
+			data->size = cSize; // should data->size be a size_t?
 			data->data = NewCString(content);
 		} else {
 			if (!IsValidData(instance->current)) {

--- a/src/envplugin/envplugin.cpp
+++ b/src/envplugin/envplugin.cpp
@@ -169,7 +169,8 @@ monitordata* EnvPlugin::OnRequestData() {
 	AppendSystemInfo(contentss);
 
 	std::string content = contentss.str();
-	data->size = static_cast<uint32>(content.length()); // should data->size be a size_t?
+	uint32 cSize = static_cast<uint32>(content.length() + 1);  // +1 to include null terminator
+	data->size = cSize; // should data->size be a size_t?
 	data->data = NewCString(content);
 	data->persistent = false;
 	aCF.logMessage(debug, "<<<EnvPlugin::OnRequestData");

--- a/src/memplugin/MemoryPlugin.cpp
+++ b/src/memplugin/MemoryPlugin.cpp
@@ -231,8 +231,8 @@ monitordata* MemoryPlugin::OnRequestData() {
 	if (sval) {
 		strcpy(sval, memorydata.c_str());
 
-		data->size = len;
 		data->data = sval;
+		data->size = len + 1;  // +1 to include null terminator
 
 	}
 	aCF.logMessage(debug, "<<<MemoryPlugin::OnRequestData");


### PR DESCRIPTION
Fix for RuntimeTools/SwiftMetrics#155 (Swift 4 branch)

Adds 1 to the size field for data which has been converted to a c string (null-terminated).

The size field did not reflect the addition of the extra null terminator byte.  This led to a potential problem when this data is then copied and used as the basis of a Swift `String`, because the null terminator was not included in the copy.