### PR TITLE
Fix deadlock in stopAllThreads()

### DIFF
--- a/src/ibmras/common/port/aix/Thread.cpp
+++ b/src/ibmras/common/port/aix/Thread.cpp
@@ -132,9 +132,12 @@ void stopAllThreads() {
 	// wake currently sleeping threads
 	condBroadcast();
 	while (!threadMap.empty()) {
-		pthread_cancel(threadMap.top());
+		pthread_t top = threadMap.top();
+		pthread_cancel(top);
 		//wait for the thread to stop
-		pthread_join(threadMap.top(), NULL);
+		pthread_mutex_unlock(&threadMapMux);
+		pthread_join(top, NULL);
+		pthread_mutex_lock(&threadMapMux);
 		threadMap.pop();
 	}
 	pthread_mutex_unlock(&threadMapMux);

--- a/src/ibmras/common/port/linux/Thread.cpp
+++ b/src/ibmras/common/port/linux/Thread.cpp
@@ -130,9 +130,12 @@ void stopAllThreads() {
 	// wake currently sleeping threads
 	condBroadcast();
 	while (!threadMap.empty()) {
-		pthread_cancel(threadMap.top());
+		pthread_t top = threadMap.top();
+		pthread_cancel(top);
 		//wait for the thread to stop
-		pthread_join(threadMap.top(), NULL);
+		pthread_mutex_unlock(&threadMapMux);
+		pthread_join(top, NULL);
+		pthread_mutex_lock(&threadMapMux);
 		threadMap.pop();
 	}
 	pthread_mutex_unlock(&threadMapMux);

--- a/src/ibmras/common/port/osx/Thread.cpp
+++ b/src/ibmras/common/port/osx/Thread.cpp
@@ -143,9 +143,12 @@ void stopAllThreads() {
 	condBroadcast();
     /* 
 	while (!threadMap.empty()) {
-		pthread_cancel(threadMap.top());
+		pthread_t top = threadMap.top();
+		pthread_cancel(top);
 		//wait for the thread to stop
-		pthread_join(threadMap.top(), NULL);
+		pthread_mutex_unlock(&threadMapMux);
+		pthread_join(top, NULL);
+		pthread_mutex_lock(&threadMapMux);
 		threadMap.pop();
 	}
     */ 


### PR DESCRIPTION
stopAllThreads() and createThread() can deadlock (and sometimes did)
because the first function takes out the threadMapMux lock and then
tries to pthread_join() other threads.

createThread() also tries to take out the lock but if stopAllThreads()
owns it and another thread calls createThread(), then boom, the threads
would deadlock each other.  Drop the lock before calling pthread_join()
and reacquire it afterwards.

This problem was noticed on an AIX machine with Node.js Application
Metrics but since the Linux port uses identical logic, I've updated
that as well.  The MacOS port has that code commented out but that
didn't stop me from updating it anyway (but leaving it commented out.)

This change is mostly untested (couldn't get omr-agentcore to compile locally)
but it looks Obviously Correct, doesn't it?  <sup>(Famous last words!)</sup>