### PR TITLE
Create float-to-ascii function ftoa & use for floats, doubles

### DIFF
--- a/src/ibmras/common/common.h
+++ b/src/ibmras/common/common.h
@@ -31,6 +31,7 @@ std::string itoa(T t) {
 	s << t;
 	return s.str();
 #endif
+}
 
 template <class T>
 std::string ftoa(T t) {

--- a/src/ibmras/common/common.h
+++ b/src/ibmras/common/common.h
@@ -32,6 +32,7 @@ std::string itoa(T t) {
 	return s.str();
 #endif
 
+template <class T>
 std::string ftoa(T t) {
 #ifdef _WINDOWS
     return std::to_string(static_cast<long double>(t));

--- a/src/ibmras/common/common.h
+++ b/src/ibmras/common/common.h
@@ -31,6 +31,15 @@ std::string itoa(T t) {
 	s << t;
 	return s.str();
 #endif
+
+std::string ftoa(T t) {
+#ifdef _WINDOWS
+    return std::to_string(static_cast<long double>(t));
+#else
+	std::stringstream s;
+	s << t;
+	return s.str();
+#endif
 }
 
 }

--- a/src/ibmras/common/data/json/JSON.h
+++ b/src/ibmras/common/data/json/JSON.h
@@ -35,7 +35,7 @@ class JSONStat {
 public:
 	JSONStat(const char* name) { this->name = name; value = NULL; }
 	void setValue(char* value) { this->value = value;}
-	void setValue(double value) { this->value = ibmras::common::itoa(value); };
+	void setValue(double value) { this->value = ibmras::common::ftoa(value); };
 	const char* getName();
 	char* getValue();
 private:


### PR DESCRIPTION
(Windows only) By statically converting all types to `long long`, `ibmras::common::itoa()` will remove all decimal places if sent a `float`, `double` or `long double`, for example reducing the double `0.7455331273234` to the string `"0"`. This PR introduces a complimentary function `ibmras::common::ftoa()` so that decimals can be preserved through a cast to `long double`. It also updates the call for files passing in such values.