### PR TITLE
Change plugin library suffixes on AIX to be .so

### DIFF
--- a/src/ibmras/monitoring/agent/Agent.cpp
+++ b/src/ibmras/monitoring/agent/Agent.cpp
@@ -43,9 +43,7 @@ const char* LIBSUFFIX = ".dll";
 #define AGENT_DECL
 const char PATHSEPARATOR = '/';
 const char* LIBPREFIX = "lib";
-#if defined(AIX)
-const char* LIBSUFFIX = ".a";
-#elif defined(__MACH__) || defined(__APPLE__)
+#if defined(__MACH__) || defined(__APPLE__)
 const char* LIBSUFFIX = ".dylib";
 #else
 const char* LIBSUFFIX = ".so";


### PR DESCRIPTION
Plugin libraries on AIX are unable to be loaded as they have a `.so` suffix, but the Agent is currently expecting them to have `.a`. This PR rectifies that assumption.