### PR TITLE
Fix inprocess connections for Java HealthCenter

### DIFF
--- a/src/ibmras/monitoring/connector/api/APIConnector.cpp
+++ b/src/ibmras/monitoring/connector/api/APIConnector.cpp
@@ -64,13 +64,9 @@ APICONNECTORPLUGIN_DECL void apiPushData(const char *sendData) {
 }
 
 APICONNECTORPLUGIN_DECL void sendControl(const char* topic, unsigned int length, void* message) {
-	char* nativeString = ibmras::common::util::createNativeString(topic);
-    const char* constMessage = static_cast<const char* const>(message);
-    char* nativeMessage = ibmras::common::util::createNativeString(constMessage);
-
-	plugin::receiver->receiveMessage(std::string(nativeString), length, nativeMessage);
-	ibmras::common::memory::deallocate((unsigned char**)&nativeString);
-    ibmras::common::memory::deallocate((unsigned char**)&nativeMessage);
+	char* nativeTopic = ibmras::common::util::createNativeString(topic);
+    plugin::receiver->receiveMessage(std::string(nativeTopic), length, message);
+	ibmras::common::memory::deallocate((unsigned char**)&nativeTopic);
 }
 
 } // end extern C


### PR DESCRIPTION
This PR restores the connection for Java Healthcenter's inprocess mode. The previous change to this file (nativeStringizing the message contents) was introduced for Appmetrics on z/OS support and was not tested for Health Center, which broke when that level of omr-agentcore was picked up. The decision was taken to undo that change to provide immediate relief for Health Center customers, and to put a future fix into z/Appmetrics to cope.