### PR TITLE
Allow semaphore reuse for z/OS

### DIFF
--- a/src/ibmras/common/port/Semaphore.h
+++ b/src/ibmras/common/port/Semaphore.h
@@ -34,13 +34,16 @@ namespace port {
 /* class to provide semaphore semantics */
 class Semaphore {
 public:
-	Semaphore(uint32 initial, uint32 max);					/* semaphore initial and max count */
-	void inc();												/* increase the semaphore count */
-	bool wait(uint32 timeout);								/* decrement the semaphore count */
-	~Semaphore();											/* OS cleanup of semaphore */
+	Semaphore(uint32 initial, uint32 max, const char *sourceName);  /* semaphore initial and max count, source name */
+	void inc();									                    /* increase the semaphore count */
+	bool wait(uint32 timeout);                                      /* decrement the semaphore count */
+	~Semaphore();                                                   /* OS cleanup of semaphore */
+#if defined(_ZOS)
+    int open(int* semid);                                           /* Either create a new semaphore or open an existing one*/
+#endif 
 private:
-	void* handle;											/* opaque handle to platform data structure */
-#if defined __MACH__
+	void* handle;											 /* opaque handle to platform data structure */
+#if defined __MACH__ || defined(_ZOS)
     std::string name;
 #endif
 };

--- a/src/ibmras/common/port/aix/Thread.cpp
+++ b/src/ibmras/common/port/aix/Thread.cpp
@@ -143,10 +143,10 @@ void stopAllThreads() {
 	pthread_mutex_unlock(&threadMapMux);
 }
 
-Semaphore::Semaphore(uint32 initial, uint32 max) {
+Semaphore::Semaphore(uint32 initial, uint32 max, const char* sourceName) {
 	if (!stopping) {
 		handle = new sem_t;
-		IBMRAS_DEBUG(fine,"in thread.cpp creating CreateSemaphoreA");
+		IBMRAS_DEBUG_1(fine,"in thread.cpp creating semaphore for source %s", sourceName);
 		int result;
 		result = sem_init(reinterpret_cast<sem_t*>(handle), 0, initial);
 		if (result) {

--- a/src/ibmras/common/port/linux/Thread.cpp
+++ b/src/ibmras/common/port/linux/Thread.cpp
@@ -141,10 +141,10 @@ void stopAllThreads() {
 	pthread_mutex_unlock(&threadMapMux);
 }
 
-Semaphore::Semaphore(uint32 initial, uint32 max) {
+Semaphore::Semaphore(uint32 initial, uint32 max, const char* sourceName) {
 	if (!stopping) {
 		handle = new sem_t;
-		IBMRAS_DEBUG(fine,"in thread.cpp creating CreateSemaphoreA");
+        IBMRAS_DEBUG_1(fine,"in thread.cpp creating semaphore for source %s", sourceName);
 		int result;
 		result = sem_init(reinterpret_cast<sem_t*>(handle), 0, initial);
 		if (result) {

--- a/src/ibmras/common/port/osx/Thread.cpp
+++ b/src/ibmras/common/port/osx/Thread.cpp
@@ -155,14 +155,14 @@ void stopAllThreads() {
 	pthread_mutex_unlock(&threadMapMux);
 }
 
-Semaphore::Semaphore(uint32 initial, uint32 max) {
+Semaphore::Semaphore(uint32 initial, uint32 max, const char* sourceName) {
 	if (!stopping) {
         name = "/hc/";
         name.append(ibmras::common::itoa(getpid()));
         name.append("/");
         name.append(ibmras::common::itoa(pthread_self()));
 		handle = new sem_t;
-		IBMRAS_DEBUG_1(fine, "in thread.cpp creating semaphore %s", name.c_str());
+		IBMRAS_DEBUG_2(fine, "in thread.cpp creating semaphore %s for %s", name.c_str(), sourceName);
 
 		handle = sem_open(name.c_str(), O_CREAT | O_EXCL, S_IRWXU | S_IRWXG | S_IRWXO, initial);
         int i=0;

--- a/src/ibmras/common/port/windows/Thread.cpp
+++ b/src/ibmras/common/port/windows/Thread.cpp
@@ -64,9 +64,9 @@ void stopAllThreads() {
 	IBMRAS_DEBUG(fine,"in thread.cpp->stopAllThreads");
 }
 
-Semaphore::Semaphore(uint32 initial, uint32 max) {
+Semaphore::Semaphore(uint32 initial, uint32 max, const char* sourceName) {
 	handle = new HANDLE;
-	IBMRAS_DEBUG(fine,  "in thread.cpp creating CreateSemaphoreA");
+    IBMRAS_DEBUG_1(fine,"in thread.cpp creating semaphore for source %s", sourceName);
 	handle = CreateSemaphoreA(NULL, initial, max, NULL);
 	if(handle == NULL) {
 		IBMRAS_DEBUG_1(warning,  "Failed to create semaphore : error code %d", GetLastError());

--- a/src/ibmras/common/util/FileUtils.cpp
+++ b/src/ibmras/common/util/FileUtils.cpp
@@ -42,7 +42,7 @@ namespace util {
 
 IBMRAS_DEFINE_LOGGER("FileUtils");
 
-bool ibmras::common::util::createDirectory(std::string& path) {
+bool createDirectory(std::string& path) {
 	IBMRAS_DEBUG(debug, ">>>FileUtils::createDirectory");
 	bool created = false;
 
@@ -130,7 +130,7 @@ bool ibmras::common::util::createDirectory(std::string& path) {
 	return created;
 }
 
-bool ibmras::common::util::createFile(std::string& path) {
+bool createFile(std::string& path) {
 	bool created = false;
     const char* pathName = path.c_str();
     IBMRAS_DEBUG_1(debug, ">>>FileUtils::createFile(), path = %s", pathName);

--- a/src/ibmras/common/util/FileUtils.cpp
+++ b/src/ibmras/common/util/FileUtils.cpp
@@ -29,37 +29,38 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <cstring>
+#include <unistd.h>
+#include <fcntl.h>
 #endif
+
+#define BASEFILEPERM (S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH)
+#define BASEDIRPERM (S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH)
 
 namespace ibmras {
 namespace common {
 namespace util {
 
-
-
 IBMRAS_DEFINE_LOGGER("FileUtils");
 
-bool ibmras::common::util::FileUtils::createDirectory(std::string& path) {
-	IBMRAS_DEBUG(debug, ">>>HLConnector::createDirectory");
+bool ibmras::common::util::createDirectory(std::string& path) {
+	IBMRAS_DEBUG(debug, ">>>FileUtils::createDirectory");
 	bool created = false;
 
 	const char* pathName = path.c_str();
 
 #if defined(WINDOWS)
 	DWORD dirAttr;
-	IBMRAS_DEBUG_1(debug, "Creating directory: %s", pathName);
 	dirAttr = GetFileAttributes(reinterpret_cast<LPCTSTR>(pathName));
 
 	if(INVALID_FILE_ATTRIBUTES == dirAttr) {
 		switch (GetLastError()) {
 			case ERROR_PATH_NOT_FOUND:
-				IBMRAS_DEBUG(warning, "The directory was not found");
-				IBMRAS_DEBUG_1(debug, "Creating directory: %s", pathName);
+				IBMRAS_DEBUG_1(fine, "Directory %s was not found - creating", pathName);
 				if(!CreateDirectory(reinterpret_cast<LPCTSTR>(pathName), NULL)) {
 					switch (GetLastError()) {
 						//if the directory already exists we will use it instead of the current one.
 						case ERROR_ALREADY_EXISTS:
-							IBMRAS_DEBUG(warning, "The specified directory already exists.");
+							IBMRAS_DEBUG_1(fine, "Directory %s already exists.", pathName);
 							created = true;
 							break;
 						case ERROR_PATH_NOT_FOUND:
@@ -67,6 +68,7 @@ bool ibmras::common::util::FileUtils::createDirectory(std::string& path) {
 							break;
 					}
 				} else {
+                    IBMRAS_DEBUG_1(debug, "Directory %s created.", pathName);
 					created = true;
 				}
 				break;
@@ -77,12 +79,11 @@ bool ibmras::common::util::FileUtils::createDirectory(std::string& path) {
 			IBMRAS_DEBUG(warning, "The network path was not found.");
 			break;
 			default:
-			IBMRAS_DEBUG(warning, "The directory could not be found, permissions?.");
-			IBMRAS_DEBUG_1(debug, "Creating directory: %s", pathName);
+			IBMRAS_DEBUG(fine, "Directory %s could not be found, permissions? Attempting creation.", pathName);
 			if(!CreateDirectory(reinterpret_cast<LPCTSTR>(pathName), NULL)) {
 				switch (GetLastError()) {
 					case ERROR_ALREADY_EXISTS:
-					IBMRAS_DEBUG(warning, "The specified directory already exists.");
+					IBMRAS_DEBUG_1(fine, "Directory %s already exists.", pathName);
 					created = true;
 					break;
 					case ERROR_PATH_NOT_FOUND:
@@ -90,42 +91,136 @@ bool ibmras::common::util::FileUtils::createDirectory(std::string& path) {
 					break;
 				}
 			} else {
+                IBMRAS_DEBUG_1(debug, "Directory %s created.", pathName);
 				created = true;
+			}
+		}
+	} else {
+        IBMRAS_DEBUG_1(debug, "Directory %s already exists", pathName);
+        created = true;
+    }
+
+#else
+	struct stat dir;
+	IBMRAS_DEBUG_1(debug, "Pathname = %s", pathName);
+	if (stat(pathName, &dir)) {
+		IBMRAS_DEBUG_1(fine, "Directory %s does not exist. Attempting creation", pathName);
+		if (-1 == mkdir(pathName, BASEDIRPERM)) {
+			if(EEXIST == errno) {
+				IBMRAS_DEBUG_1(debug, "Directory % already existed", pathName);
+				created = true;
+			} else {
+                IBMRAS_DEBUG_2(warning, "Directory %s could not be created: %s", pathName, strerror(errno));
+            }
+		} else {
+			IBMRAS_DEBUG_1(debug, "Directory %s was created", pathName);
+            chmod(pathName,BASEDIRPERM);
+			created = true;
+		}
+	} else {
+		IBMRAS_DEBUG_1(fine, "stat() returned 0, checking whether %s is an existing directory", pathName);
+		if(S_ISDIR(dir.st_mode)) {
+            IBMRAS_DEBUG_1(debug, "Directory %s does exist", pathName);
+			created = true;
+		}
+	}
+#endif
+	IBMRAS_DEBUG(debug, "<<<FileUtils::createDirectory()");
+
+	return created;
+}
+
+bool ibmras::common::util::createFile(std::string& path) {
+	bool created = false;
+    const char* pathName = path.c_str();
+    IBMRAS_DEBUG_1(debug, ">>>FileUtils::createFile(), path = %s", pathName);
+
+#if defined(WINDOWS)
+    HANDLE fileHandle;
+	DWORD fileAttr;
+	fileAttr = GetFileAttributes(reinterpret_cast<LPCTSTR>(pathName));
+
+	if(INVALID_FILE_ATTRIBUTES == fileAttr) {
+		switch (GetLastError()) {
+			case ERROR_PATH_NOT_FOUND:
+				IBMRAS_DEBUG_1(fine, "File %s was not found. Attempting to create.", pathName);
+				fileHandle = CreateFile(reinterpret_cast<LPCTSTR>(pathName), NULL, (GENERIC_READ | GENERIC_WRITE), 0, (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, CREATE_NEW, FILE_ATTRIBUTE_HIDDEN, NULL);
+				if(INVALID_HANDLE_VALUE == fileHandle) {
+					switch (GetLastError()) {
+						//if the directory already exists we will use it instead of the current one.
+						case ERROR_FILE_EXISTS:
+							IBMRAS_DEBUG_1(warning, "File %s already exists.", pathName);
+							created = true;
+							break;
+						case ERROR_PATH_NOT_FOUND:
+							IBMRAS_DEBUG_1(warning, "The system cannot find file %s.", pathName);
+							break;
+					}
+				} else {
+					created = true;
+                    CloseHandle(fileHandle);
+				}
+				break;
+			case ERROR_INVALID_NAME:
+			IBMRAS_DEBUG(warning, "The filename, directory name, or volume label syntax is incorrect");
+			break;
+			case ERROR_BAD_NETPATH:
+			IBMRAS_DEBUG(warning, "The network path was not found.");
+			break;
+			default:
+			IBMRAS_DEBUG_1(fine, "File %s could not be found, permissions? Attempting to create", pathName);
+			fileHandle = CreateFile(reinterpret_cast<LPCTSTR>(pathName), NULL, (GENERIC_READ | GENERIC_WRITE), 0, (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, CREATE_NEW, FILE_ATTRIBUTE_HIDDEN, NULL);
+			if(INVALID_HANDLE_VALUE == fileHandle) {
+				switch (GetLastError()) {
+					case ERROR_FILE_EXISTS:
+					IBMRAS_DEBUG_1(fine, "File %s already exists.", pathName);
+					created = true;
+					break;
+					case ERROR_PATH_NOT_FOUND:
+					IBMRAS_DEBUG_1(warning, "The system cannot find file %s.", pathName);
+					break;
+				}
+			} else {
+				created = true;
+                CloseHandle(fileHandle);
 			}
 		}
 	}
 
 #else
-	struct stat dir;
-	IBMRAS_DEBUG_1(debug, "Pathname...%s\n", pathName);
-	if (stat(pathName, &dir)) {
-		IBMRAS_DEBUG_1(debug, "Directory does not exist, creating...%s\n", pathName);
-		if (mkdir(pathName, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) {
-			IBMRAS_DEBUG_1(debug, "Directory could not be created: ", strerror(errno));
+	struct stat file;
+    int fd;
+	if (stat(pathName, &file)) {
+		IBMRAS_DEBUG_1(debug, "File %s does not exist, attempting creation", pathName);
+        fd = open(pathName, (O_CREAT|O_EXCL|O_WRONLY), BASEFILEPERM);
+		if (-1 == fd) {
 			if(EEXIST == errno) {
-				IBMRAS_DEBUG_1(debug, "Directory % already existed", pathName);
+				IBMRAS_DEBUG_1(debug, "File %s already exists", pathName);
 				created = true;
-			}
+			} else {
+                IBMRAS_DEBUG_2(debug, "File %s could not be created: %s", pathName, strerror(errno));
+            }
 		} else {
-			IBMRAS_DEBUG_1(debug, "Directory %s was created: ", pathName);
+			IBMRAS_DEBUG_1(debug, "File %s was created", pathName);
+            close(fd);
+            chmod(pathName, BASEFILEPERM);
 			created = true;
 		}
 	} else {
-		IBMRAS_DEBUG(debug, "stat() returned 0, we'll check whether it was an existing directory");
-		if(S_ISDIR(dir.st_mode)) {
-			created = true;
-		}
+		IBMRAS_DEBUG_1(debug, "stat() returned 0, checking whether %s is an existing file", pathName);
+		if(S_ISDIR(file.st_mode)) {
+            IBMRAS_DEBUG_1(warning, "File could not be created: %s is a directory", pathName);
+		} else {
+            IBMRAS_DEBUG_1(debug, "File %s does exist", pathName);
+            created = true;
+        }
 	}
 #endif
-	IBMRAS_DEBUG(debug, "<<<HLConnector::createDirectory()");
 
+    IBMRAS_DEBUG(debug, "<<<FileUtils::createfile()");
 	return created;
 }
 
-//bool ibmras::common::util::FileUtils::isWriteable(std::string dir) {
-//	return true;
-//
-//}
 
 }//util
 }//common

--- a/src/ibmras/common/util/FileUtils.h
+++ b/src/ibmras/common/util/FileUtils.h
@@ -24,13 +24,8 @@ namespace ibmras {
 namespace common {
 namespace util {
 
-class FileUtils {
-
-public:
-
 bool createDirectory(std::string& path);
-
-};
+bool createFile(std::string& path);
 
 }
 }

--- a/src/ibmras/monitoring/agent/threads/WorkerThread.cpp
+++ b/src/ibmras/monitoring/agent/threads/WorkerThread.cpp
@@ -25,7 +25,6 @@ namespace agent {
 namespace threads {
 
 extern IBMRAS_DECLARE_LOGGER;
-IBMRAS_DEFINE_LOGGER("WorkerThread");
 
 
 WorkerThread::WorkerThread(pullsource* pullSource) : semaphore(0, 1, pullSource->header.name), data(threadEntry, cleanUp), countdown(0) {
@@ -102,4 +101,3 @@ void* WorkerThread::processLoop() {
 }
 }
 } /* end of namespace threads */
-

--- a/src/ibmras/monitoring/agent/threads/WorkerThread.cpp
+++ b/src/ibmras/monitoring/agent/threads/WorkerThread.cpp
@@ -25,9 +25,10 @@ namespace agent {
 namespace threads {
 
 extern IBMRAS_DECLARE_LOGGER;
+IBMRAS_DEFINE_LOGGER("WorkerThread");
 
 
-WorkerThread::WorkerThread(pullsource* pullSource) : semaphore(0, 1), data(threadEntry, cleanUp), countdown(0) {
+WorkerThread::WorkerThread(pullsource* pullSource) : semaphore(0, 1, pullSource->header.name), data(threadEntry, cleanUp), countdown(0) {
 	source = pullSource;
 	running = false;
 	stopped = true;


### PR DESCRIPTION
This PR is in response to problems identified by OMEGAMON wrt semaphore exhaustion on z/OS. The new solution uses a temporary file system to obtain IPC keys used in the creation and reuse of semaphores. Benefits of the new solution:
  * All processes will use the existing set of semaphores rather than create their own individual ones - greatly reducing semaphore overhead for multiple processes.
  * Abnormally-terminated processes will not leave orphaned semaphores as the next process instance will pick them back up and reuse them.

Note that the loader is now required to set an agent property `platform_tempdir` which indicates where the temporary file system will be created.

A change was made to the WorkerThead and Semaphore code for all platforms to facilitate the passing through of the source name to be used as a temporary file name.

FileUtils has been updated to assist in the creation of the temporary directories and files.