### PR TITLE
Fix Windows File Util compilation errors; update version to 4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This project uses a semver-parsable X.0.Z version number for releases, where X i
 Non-release versions of this project (for example on github.com/RuntimeTools/omr-agentcore) will use semver-parsable X.0.Z-dev.B version numbers, where X.0.Z is the last release with Z incremented and B is an integer. For further information on the development process go to the  [appmetrics wiki][3]: [Developing](https://github.com/RuntimeTools/appmetrics/wiki/Developing).
 
 ## Version
-4.0.0
+4.0.1
 
 ## Release History
+`4.0.1` - Fix Windows FileUtil compilation errors.  
 `4.0.0` - Fixes for z/OS API connections and semaphore reuse.  
 `3.2.9` - Build fixes for Node 10.  
 `3.2.8` - Initial support for iPASE systems.  

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
 #    "externalbinariesdir%": "<(PRODUCT_DIR)/deploy/external/binaries",
     "externalbinariesdir%": "./plugins",
     'build_id%': '.<!(["python", "./generate_build_id.py"])',
-    'coreversion%': '4.0.0',
+    'coreversion%': '4.0.1',
     "conditions": [
       ['OS=="aix"', {
         "portdir": "aix",

--- a/src/ibmras/common/util/FileUtils.cpp
+++ b/src/ibmras/common/util/FileUtils.cpp
@@ -79,7 +79,7 @@ bool createDirectory(std::string& path) {
 			IBMRAS_DEBUG(warning, "The network path was not found.");
 			break;
 			default:
-			IBMRAS_DEBUG(fine, "Directory %s could not be found, permissions? Attempting creation.", pathName);
+			IBMRAS_DEBUG_1(fine, "Directory %s could not be found, permissions? Attempting creation.", pathName);
 			if(!CreateDirectory(reinterpret_cast<LPCTSTR>(pathName), NULL)) {
 				switch (GetLastError()) {
 					case ERROR_ALREADY_EXISTS:
@@ -144,7 +144,7 @@ bool createFile(std::string& path) {
 		switch (GetLastError()) {
 			case ERROR_PATH_NOT_FOUND:
 				IBMRAS_DEBUG_1(fine, "File %s was not found. Attempting to create.", pathName);
-				fileHandle = CreateFile(reinterpret_cast<LPCTSTR>(pathName), NULL, (GENERIC_READ | GENERIC_WRITE), 0, (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, CREATE_NEW, FILE_ATTRIBUTE_HIDDEN, NULL);
+				fileHandle = CreateFile(reinterpret_cast<LPCTSTR>(pathName), (GENERIC_READ | GENERIC_WRITE), (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, CREATE_NEW, FILE_ATTRIBUTE_HIDDEN, NULL);
 				if(INVALID_HANDLE_VALUE == fileHandle) {
 					switch (GetLastError()) {
 						//if the directory already exists we will use it instead of the current one.
@@ -169,7 +169,7 @@ bool createFile(std::string& path) {
 			break;
 			default:
 			IBMRAS_DEBUG_1(fine, "File %s could not be found, permissions? Attempting to create", pathName);
-			fileHandle = CreateFile(reinterpret_cast<LPCTSTR>(pathName), NULL, (GENERIC_READ | GENERIC_WRITE), 0, (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, CREATE_NEW, FILE_ATTRIBUTE_HIDDEN, NULL);
+			fileHandle = CreateFile(reinterpret_cast<LPCTSTR>(pathName), (GENERIC_READ | GENERIC_WRITE), (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, CREATE_NEW, FILE_ATTRIBUTE_HIDDEN, NULL);
 			if(INVALID_HANDLE_VALUE == fileHandle) {
 				switch (GetLastError()) {
 					case ERROR_FILE_EXISTS:

--- a/src/ibmras/monitoring/agent/Agent.cpp
+++ b/src/ibmras/monitoring/agent/Agent.cpp
@@ -192,7 +192,7 @@ std::string Agent::getBuildDate() {
 }
 
 std::string Agent::getVersion() {
-	return "4.0.0";
+	return "4.0.1";
 }
 
 void Agent::setLogLevels() {


### PR DESCRIPTION
This PR fixes Windows compilation errors that currently occur when building on that platform. It also prepares that fix for release as omr-agentcore version 4.0.1