### PR TITLE
Correct rpath for linux libhcapiplugin.so

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -235,6 +235,9 @@
             "<(srcdir)/common/port/Lock.cpp",
           ],
         }],
+        ['OS=="linux"', {
+          "libraries=": [ "-Wl,-rpath=\$$ORIGIN/.." ],
+        }],
       ],
     },
     {


### PR DESCRIPTION
When testing https://github.com/RuntimeTools/omr-agentcore/pull/92 on an Alpine Docker image, `npm test` failed with messages like:
```
[Tue Sep 17 08:41:06 2019] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 5.0.3.201909170840 (Agent Core 4.0.4)
[Tue Sep 17 08:41:06 2019] com.ibm.diagnostics.healthcenter.loader WARNING: Failed to open library /appmetrics/plugins/libhcapiplugin.so:Error loading shared library libagentcore.so: No such file or directory (needed by /appmetrics/plugins/libhcapiplugin.so)
```
`ldd libhcapiplugin.so` confirmed that it was unable to find `libagentcore.so` on it's rpath.

This PR adds the required rpath into `libhcapiplugin`'s linker options for Linux builds. Built and tested on Alpine and Ubuntu images - `npm test` now works on Alpine and continues to work on Ubuntu.