### PR TITLE
Prep for release 4.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This project uses a semver-parsable X.0.Z version number for releases, where X i
 Non-release versions of this project (for example on github.com/RuntimeTools/omr-agentcore) will use semver-parsable X.0.Z-dev.B version numbers, where X.0.Z is the last release with Z incremented and B is an integer. For further information on the development process go to the  [appmetrics wiki][3]: [Developing](https://github.com/RuntimeTools/appmetrics/wiki/Developing).
 
 ## Version
-4.0.4
+4.0.5
 
 ## Release History
+`4.0.5` - Fixes to support Appmetrics on Alpine.  
 `4.0.4` - Build fix for zAppmetrics, memory reporting for i.  
 `4.0.3` - Remove test code due to GPL licence.  
 `4.0.2` - Linux headless re-attach fix.  

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
 #    "externalbinariesdir%": "<(PRODUCT_DIR)/deploy/external/binaries",
     "externalbinariesdir%": "./plugins",
     'build_id%': '.<!(["python", "./generate_build_id.py"])',
-    'coreversion%': '4.0.4',
+    'coreversion%': '4.0.5',
     "conditions": [
       ['OS=="aix"', {
         "portdir": "aix",

--- a/src/ibmras/monitoring/agent/Agent.cpp
+++ b/src/ibmras/monitoring/agent/Agent.cpp
@@ -192,7 +192,7 @@ std::string Agent::getBuildDate() {
 }
 
 std::string Agent::getVersion() {
-	return "4.0.4";
+	return "4.0.5";
 }
 
 void Agent::setLogLevels() {


### PR DESCRIPTION
This PR bumps the release numbers and updates the README for releasing omr-agentcore v4.0.5