### PR TITLE
update omr-agentcore to not assume thread is running in char mode

### DIFF
--- a/src/ibmras/common/LogManager.cpp
+++ b/src/ibmras/common/LogManager.cpp
@@ -29,10 +29,6 @@
 #define VPRINT vsprintf
 #endif
 
-#ifdef _ZOS
-extern "C" int dprintf(int fd, const char *fmt, ...);
-#endif
-
 extern "C" {
 
 DECL void* ibmras_common_LogManager_getLogger(const char* name) {
@@ -60,12 +56,8 @@ void LogManager::processMsg(const std::string &msg) {
 		if (localLogFunc) {
 			localLogFunc(msg);
 		} else {
-#ifdef _ZOS
-                        dprintf(2,"%s\n",msg.c_str());
-#else
 			std::cerr << msg << '\n';
 			std::cerr.flush();
-#endif
 		}
 		return;
 	}

--- a/src/ibmras/common/util/strUtils.cpp
+++ b/src/ibmras/common/util/strUtils.cpp
@@ -137,8 +137,8 @@ void native2Ascii(char * str, bool convertToCurrentLocale) {
     {
         if (convertToCurrentLocale) {
           convertCodePage(str, expectedNativeCodepage().c_str(), "IBM-1047");
-          __etoa(str);
         }
+        __etoa(str);
     }
 #endif
 }

--- a/src/ibmras/common/util/strUtils.cpp
+++ b/src/ibmras/common/util/strUtils.cpp
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include <locale.h>
 #include <iconv.h>
+#include <_Nascii.h>
 #endif
 
 namespace ibmras {
@@ -100,12 +101,11 @@ std::string expectedNativeCodepage() {
 }
 
 
-int convertCodePage(char * str, const char* toCodePage, const char * fromCodePage) {
-  // return 0: no change, 1: changed, -1: error
+void convertCodePage(char * str, const char* toCodePage, const char * fromCodePage) {
   std::string codepage = expectedNativeCodepage();
   if (codepage.compare("IBM-1047") == 0) {
       //already in that codepage - return
-      return 0;
+      return;
   }
   char *cp = (char*)ibmras::common::memory::allocate(strlen(str) + 1);
   strcpy(cp,str);
@@ -118,32 +118,26 @@ int convertCodePage(char * str, const char* toCodePage, const char * fromCodePag
 
   if ((cd = iconv_open(toCodePage, fromCodePage)) == (iconv_t)(-1)) {
     fprintf(stderr, "Cannot open converter to %s from %s\n", toCodePage, fromCodePage);
-    return -1;
+    return;
   }
 
   rc = iconv(cd, &inptr, &inleft, &outptr, &outleft);
   if (rc == -1) {
     fprintf(stderr, "Error in converting characters\n");
   }
-  else {
-    rc = 1;
-  }
   iconv_close(cd);
   ibmras::common::memory::deallocate((unsigned char**)&cp);
-  return rc;
 }
 #endif
 
 
 void native2Ascii(char * str, bool convertToCurrentLocale) {
 #if defined(_ZOS)
-    if ( NULL != str )
+    if ( NULL != str && __isASCII() == 0 )
     {
         if (convertToCurrentLocale) {
-          int rc = convertCodePage(str, expectedNativeCodepage().c_str(), "IBM-1047");
-          if (rc==1) { 
-            __etoa(str);
-          }
+          convertCodePage(str, expectedNativeCodepage().c_str(), "IBM-1047");
+          __etoa(str);
         }
     }
 #endif


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
The previous change 182b635 regressed Java HealthCheck app, as reported by Filip Jeremic, who informed me that Java HealthCenter and its dependencies don't build with -qascii, so the related change caused the regression. The fix is to revert part of the changes to omr-agentcore so native2Ascii() performs its conversion only if the calling thread is not running in character mode.