### PR TITLE
Remove stray enum instance

### DIFF
--- a/org.eclipse.paho.mqtt.c/src/Log.h
+++ b/org.eclipse.paho.mqtt.c/src/Log.h
@@ -40,7 +40,7 @@ enum LOG_LEVELS {
 	LOG_ERROR,
 	LOG_SEVERE,
 	LOG_FATAL,
-} Log_levels;
+};
 
 
 /*BE


### PR DESCRIPTION
This `enum LOG_LEVELS` declaration also included a _variable name_,
causing https://github.com/RuntimeTools/appmetrics/issues/641. It ended
up defining a `Log_levels` variable in every compilation unit that
included "Log.h", which then caused duplicate symbols at link time.

I don't know if there was a reason for this definition, but it looks
like a bug to me … if not, maybe it can be fixed by just putting a
`static` in front? idk.

Thanks!