### PR TITLE
Fix to avoid intermittent crashes while shutdown on zos

### DIFF
--- a/src/ibmras/monitoring/agent/threads/WorkerThread.cpp
+++ b/src/ibmras/monitoring/agent/threads/WorkerThread.cpp
@@ -43,7 +43,11 @@ void WorkerThread::start() {
 }
 
 void WorkerThread::stop() {
-	source->complete(NULL);
+	// Issue 102: By completing pull sources too early might
+	// intermittenlty destruct while still in processLoop.
+	#if !defined(_WINDOWS) && !defined(_ZOS)
+		source->complete(NULL);
+	#endif
 	running = false;
 
 	// Issue 99: By setting stopped to true too early, ThreadPool


### PR DESCRIPTION
While processLoop is running don't destruct the threads too early on zos and windows to avoid intermittent crashes.

Fixes #102

Signed-off-by: Ravali Yatham \<rayatha1@in.ibm.com\>