### PR TITLE
Replace semaphore with a state flag on zos

### DIFF
--- a/src/ibmras/monitoring/agent/threads/WorkerThread.h
+++ b/src/ibmras/monitoring/agent/threads/WorkerThread.h
@@ -43,7 +43,11 @@ private:
 	void* processLoop();
 	bool running;
 	bool stopped;
+#if defined(_ZOS)
+	bool isDataPullAllowed;
+#else
 	ibmras::common::port::Semaphore semaphore;		/* sempahore to control data processing */
+#endif
 	pullsource* source;		/* source to pull data from */
 	ibmras::common::port::ThreadData data;
 	int countdown;


### PR DESCRIPTION
This change is to avoid semaphore contention across multiple processes. Currently on ZOS for each of the seven HC threads a unique semaphore ID will be created and are reused for all the processes in the system.

Signed-off-by: Ravali Yatham <rayatha1@in.ibm.com>